### PR TITLE
Fix the import of MutableMapping to work on Python3.10

### DIFF
--- a/flask_nav/__init__.py
+++ b/flask_nav/__init__.py
@@ -46,7 +46,7 @@ class NavbarRenderingError(Exception):
     pass
 
 
-class ElementRegistry(collections.MutableMapping):
+class ElementRegistry(collections.abc.MutableMapping):
     def __init__(self):
         self._elems = {}
 


### PR DESCRIPTION

Updates the import of the MutableMapping class from collections. The previous
import was from `collections`, and in Python3.10+ the import needs to change
to `collections.abc`. Tests pass on change.